### PR TITLE
feat(build): support yarn 2.x

### DIFF
--- a/bin/compile
+++ b/bin/compile
@@ -36,7 +36,7 @@ cleanup_cache
 download_node
 install_node
 install_npm
-if [ -f "$assets_dir/yarn.lock" ]; then
+if [ -f "$assets_dir/yarn.lock" || [ -d "$assets_dir/.yarn" ] || [ -f "$assets_dir/.pnp.*"]; then
   install_yarn "$heroku_dir/yarn"
 fi
 

--- a/compile
+++ b/compile
@@ -1,4 +1,4 @@
-if [ -f "$assets_dir/yarn.lock" ]; then
+if [ -f "$assets_dir/yarn.lock" || [ -d "$assets_dir/.yarn" ] || [ -f "$assets_dir/.pnp.*"]; then
   yarn deploy
 else
   npm run deploy

--- a/lib/build.sh
+++ b/lib/build.sh
@@ -113,7 +113,7 @@ install_npm() {
 install_yarn() {
   local dir="$1"
 
-  if [ ! $yarn_version ]; then
+  if [ ! $yarn_version ] || is_yarn2_configured; then
     echo "Downloading and installing yarn lastest..."
     local download_url="https://yarnpkg.com/latest.tar.gz"
   else
@@ -136,6 +136,10 @@ install_yarn() {
   chmod +x $dir/bin/*
   PATH=$dir/bin:$PATH
   echo "Installed yarn $(yarn --version)"
+
+  if is_yarn2_configured; then
+    yarn set version berry
+  fi
 }
 
 install_and_cache_deps() {
@@ -256,4 +260,18 @@ remove_node() {
   info "Removing node and node_modules"
   rm -rf $assets_dir/node_modules
   rm -rf $heroku_dir/node
+}
+
+is_yarn2_configured() {
+  if [ ! $yarn_version ]; then
+    return $(false)
+  else
+    local regex='[^0-9]*\([0-9]*\)[.]\([0-9]*\)[.]\([0-9]*\)\([0-9A-Za-z-]*\)'
+    local major_version=`echo $yarn_version | sed -e "s#$regex#\1#"`
+    if [ $major_version -ge 2 ]; then
+      return $(true)
+    else
+      return $(false)
+    fi
+  fi
 }


### PR DESCRIPTION
this PR adds support yarn 2.x

i had offered these changes to the original `gjaldon/heroku-buildpack-phoenix-static` project over 2 years ago (https://github.com/gjaldon/heroku-buildpack-phoenix-static/pull/116) and have been use my fork since then

offering these changes to the Gigalixir fork since that seems to be getting maintained