### PR TITLE
fix: empty node_modules dir in cache

### DIFF
--- a/lib/build.sh
+++ b/lib/build.sh
@@ -211,7 +211,9 @@ install_and_cache_deps() {
   if [ -d $cache_dir/node_modules ]; then
     info "Loading node modules from cache"
     mkdir node_modules
-    cp -R $cache_dir/node_modules/* node_modules/
+    if [ ! -z $(ls -A $cache_dir/node_modules) ]; then
+      cp -R $cache_dir/node_modules/* node_modules/
+    fi
   fi
 
   info "Installing node modules"


### PR DESCRIPTION
On cache clear, the node_modules directory exists, but has no files in it.

The `cp -R` command was failing.  This will protect that call by ensuring there are files in the directory first.