### PR TITLE
fix: error message on install resolve failure

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,17 @@
+name: CI
+
+on: 
+  pull_request:
+    branches:
+      - main
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v3
+
+    - name: run tests
+      run: |
+        for tst in test/*; do $tst; done

--- a/lib/build.sh
+++ b/lib/build.sh
@@ -46,7 +46,7 @@ resolve_node_version() {
     node_version=$(echo "$node_file" | sed -E 's/.*node-v([0-9]+\.[0-9]+\.[0-9]+).*/\1/')
     node_url="${base_url}/v${node_version}/${node_file//\"/}"
   else
-    fail_bin_install node $node_version;
+    fail_bin_install node $node_version "Unable to resolve version"
   fi
 
   # get the corresponding checksum
@@ -327,4 +327,13 @@ remove_node() {
   info "Removing node and node_modules"
   rm -rf $assets_dir/node_modules
   rm -rf $heroku_dir/node
+}
+
+fail_bin_install() {
+  local bin="$1"
+  local version="$2"
+  local reason="$3"
+
+  echo "Error installing ${bin} ${version}: ${reason}"
+  exit 1
 }

--- a/test/.test_support.sh
+++ b/test/.test_support.sh
@@ -6,12 +6,13 @@ PASSED_ALL_TESTS=false
 
 # make a temp dir for test files/directories
 TEST_DIR=$(mktemp -d -t gigalixir-buildpack-phoenix-static_XXXXXXXXXX)
+ECHO_CONTENT=()
 cleanup() {
   rm -rf ${TEST_DIR}
   if $PASSED_ALL_TESTS; then
-    echo -e "  \e[0;32mTest Suite PASSED\e[0m"
+    /bin/echo -e "  \e[0;32mTest Suite PASSED\e[0m"
   else
-    echo -e "  \e[0;31mFAILED\e[0m"
+    /bin/echo -e "  \e[0;31mFAILED\e[0m"
   fi
   exit
 }
@@ -31,10 +32,11 @@ info() {
 # helper functions
 test() {
   failed=false
-  echo "  TEST: $@"
+  ECHO_CONTENT=()
+  /bin/echo "  TEST: $@"
 }
 
 suite() {
   failed=false
-  echo -e "\e[0;36mSUITE: $@\e[0m"
+  /bin/echo -e "\e[0;36mSUITE: $@\e[0m"
 }

--- a/test/fail_bin_install_test.sh
+++ b/test/fail_bin_install_test.sh
@@ -1,0 +1,33 @@
+#!/usr/bin/env bash
+
+set -e
+
+SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )"
+source $SCRIPT_DIR/.test_support.sh
+
+# include source file
+source $SCRIPT_DIR/../lib/build.sh
+
+# override functions used
+echo() {
+  ECHO_CONTENT=("${ECHO_CONTENT[@]}" "$@")
+}
+exit() {
+  EXIT_CODE=$1
+}
+
+# TESTS
+######################
+suite "fail_bin_install"
+
+
+  test "echos error to user"
+
+    fail_bin_install "node" "1.2.3" "bad version"
+
+    [ "Error installing node 1.2.3: bad version" == "${ECHO_CONTENT[0]}" ]
+    [ "1" -eq "$EXIT_CODE" ]
+
+
+
+PASSED_ALL_TESTS=true


### PR DESCRIPTION
fail_bin_install was an undefined function, leading to unactionable error messages like this:
```
       Resolving node version 12.1.0...
/tmp/buildpackg5ObS/lib/build.sh: line 49: fail_bin_install: command not found
```