### PR TITLE
fix: missing directory on yarn install

### DIFF
--- a/lib/build.sh
+++ b/lib/build.sh
@@ -228,6 +228,7 @@ install_and_cache_deps() {
 
   info "Installing node modules"
   if [ -f "$assets_dir/yarn.lock" ]; then
+    mkdir -p $assets_dir/node_modules
     install_yarn_deps
   else
     install_npm_deps


### PR DESCRIPTION
On a fresh setup with yarn.lock in the assets directory and no node_modules directory, yarn dependencies fail to install.