### PR TITLE
feat: detect missing deploy script

### DIFF
--- a/compile
+++ b/compile
@@ -1,6 +1,6 @@
 if [ -f "$assets_dir/yarn.lock" ]; then
   yarn deploy
-elif [ -f "$assets_dir/package.json" ]; then
+elif [ -f "$assets_dir/package.json" ] && jq -e '.scripts.deploy' $assets_dir/package.json > /dev/null; then
   npm run deploy
 else
   cd $phoenix_dir

--- a/test/compile_test.sh
+++ b/test/compile_test.sh
@@ -1,0 +1,53 @@
+#!/usr/bin/env bash
+
+set -e
+
+SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )"
+source $SCRIPT_DIR/.test_support.sh
+
+# override mix command
+MIX_ARGS=()
+mix() {
+  MIX_ARGS=("${MIX_ARGS[@]}" "$@")
+}
+
+NPM_ARGS=""
+npm() {
+  NPM_ARGS="$@"
+}
+
+# TESTS
+######################
+suite "compile"
+
+
+  test "package.json with deploy script"
+
+    echo '{
+  "scripts": {
+    "deploy": "echo deploying"
+  }
+}' > $assets_dir/package.json
+    source $SCRIPT_DIR/../compile
+    [ "$NPM_ARGS" == "run deploy" ]
+
+    rm $assets_dir/package.json
+    NPM_ARGS=""
+    MIX_ARGS=()
+
+
+
+  test "package.json without deploy script"
+
+    echo '{
+  "scripts": {
+    "other": "echo deploying"
+  }
+}' > $assets_dir/package.json
+    source $SCRIPT_DIR/../compile
+    [ -z "$NPM_ARGS" ]
+    [ "${MIX_ARGS[0]}" == "assets.deploy" ]
+
+
+
+PASSED_ALL_TESTS=true


### PR DESCRIPTION
When a package.json file exists, but the `deploy` script is not present, fallback to mix compilation of assets.
