### PR TITLE
fix: prefer modern phoenix

### DIFF
--- a/bin/compile
+++ b/bin/compile
@@ -23,7 +23,7 @@ source ${build_pack_dir}/lib/common.sh
 source ${build_pack_dir}/lib/build.sh
 
 
-head "Loading configuration and environment"
+header "Loading configuration and environment"
 load_previous_npm_node_versions
 load_config
 export_config_vars
@@ -31,7 +31,7 @@ export_mix_env
 
 resolve_node_version
 
-head "Installing binaries"
+header "Installing binaries"
 cleanup_cache
 download_node
 install_node
@@ -40,12 +40,12 @@ if [ -f "$assets_dir/yarn.lock" ]; then
   install_yarn "$heroku_dir/yarn"
 fi
 
-head "Building dependencies"
+header "Building dependencies"
 install_and_cache_deps
 
 compile
 
-head "Finalizing build"
+header "Finalizing build"
 cache_versions
 finalize_node
 

--- a/lib/phoenix_version.exs
+++ b/lib/phoenix_version.exs
@@ -1,0 +1,4 @@
+[lock_file_path | _] = System.argv()
+{lock_map, _} = Code.eval_file(lock_file_path)
+[:hex,:phoenix,version] ++ _rest = Tuple.to_list(Map.get(lock_map,:"phoenix"))
+IO.puts(version)

--- a/phoenix_static_buildpack.config
+++ b/phoenix_static_buildpack.config
@@ -5,4 +5,4 @@ yarn_version=0.27.5
 phoenix_relative_path=.
 remove_node=false
 assets_path=.
-phoenix_ex=phoenix
+phoenix_ex=


### PR DESCRIPTION
The buildpack assumes that a user is using phoenix 1.2 or earlier.  Unfortunately this occassionally causes issues when it cannot detect 1.3 or greater properly.  The mix task namespace gets set to phoenix instead of phx.  

This PR changes the default to `phx` and assumes 1.3 or greater.  Only if mix.lock shows a phx version lower than 1.3.0 will we attempt to use the `phoenix` namespace.
