### PR TITLE
refactor: extract output funcs to shared lib

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,5 +13,4 @@ jobs:
     - uses: actions/checkout@v3
 
     - name: run tests
-      run: |
-        for tst in test/*.sh; do $tst; done
+      run: make test

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,7 @@
+.PHONY: test
+
+test:
+	@set -e; for tst in test/*.sh; do \
+		[ -x "$$tst" ] || continue; \
+		"$$tst"; \
+	done

--- a/bin/compile
+++ b/bin/compile
@@ -19,11 +19,12 @@ cache_dir=$(cd $2 && pwd)
 env_dir=$(cd $3 && pwd)
 heroku_dir=$build_dir/.heroku
 
+source ${build_pack_dir}/lib/output_funcs.sh
 source ${build_pack_dir}/lib/common.sh
 source ${build_pack_dir}/lib/build.sh
 
 
-header "Loading configuration and environment"
+output_section "Loading configuration and environment"
 load_previous_npm_node_versions
 load_config
 export_config_vars
@@ -31,7 +32,7 @@ export_mix_env
 
 resolve_node_version
 
-header "Installing binaries"
+output_section "Installing binaries"
 cleanup_cache
 download_node
 install_node
@@ -43,12 +44,12 @@ if [ -f "$assets_dir/pnpm-lock.yaml" ]; then
   install_pnpm "$heroku_dir/pnpm"
 fi
 
-header "Building dependencies"
+output_section "Building dependencies"
 install_and_cache_deps
 
 compile
 
-header "Finalizing build"
+output_section "Finalizing build"
 cache_versions
 finalize_node
 

--- a/lib/build.sh
+++ b/lib/build.sh
@@ -1,7 +1,7 @@
 cleanup_cache() {
   if [ $clean_cache = true ]; then
-    info "clean_cache option set to true."
-    info "Cleaning out cache contents"
+    output_line "clean_cache option set to true."
+    output_line "Cleaning out cache contents"
     rm -rf $cache_dir/npm-version
     rm -rf $cache_dir/node-version
     rm -rf $cache_dir/phoenix-static
@@ -81,7 +81,7 @@ download_node() {
 
   validate_cached_node
   if $download_complete; then
-    info "Using cached node ${node_version}..."
+    output_line "Using cached node ${node_version}..."
   else
 
     # three attempts to download the file successfully
@@ -137,7 +137,7 @@ cleanup_old_node() {
   # has the format "5.6.0"
 
   if [ $clean_cache = true ] || [ $old_node != v$node_version ] && [ -f $old_node_dir ]; then
-    info "Cleaning up old Node $old_node"
+    output_line "Cleaning up old Node $old_node"
     rm $old_node_dir
 
     local bower_components_dir=$cache_dir/bower_components
@@ -183,11 +183,11 @@ install_node() {
 install_npm() {
   # Optionally bootstrap a different npm version
   if [ ! $npm_version ] || [[ `npm --version` == "$npm_version" ]]; then
-    info "Using default npm version `npm --version`"
+    output_line "Using default npm version `npm --version`"
   else
-    info "Downloading and installing npm $npm_version (replacing version `npm --version`)..."
+    output_line "Downloading and installing npm $npm_version (replacing version `npm --version`)..."
     cd $build_dir
-    npm install --unsafe-perm --quiet -g npm@$npm_version 2>&1 >/dev/null | indent
+    npm install --unsafe-perm --quiet -g npm@$npm_version 2>&1 >/dev/null | output_indent
   fi
 }
 
@@ -246,14 +246,14 @@ install_and_cache_deps() {
     cd $assets_dir
 
     if [ -d $cache_dir/node_modules ]; then
-      info "Loading node modules from cache"
+      output_line "Loading node modules from cache"
       mkdir node_modules
       if [ -z $(find $cache_dir/node_modules -maxdepth 0 -empty) ]; then
         rsync -a $cache_dir/node_modules/ node_modules/
       fi
     fi
 
-    info "Installing node modules"
+    output_line "Installing node modules"
     if [ -f "$assets_dir/yarn.lock" ]; then
       mkdir -p $assets_dir/node_modules
       install_yarn_deps
@@ -264,7 +264,7 @@ install_and_cache_deps() {
     fi
 
     if [ -d node_modules ]; then
-      info "Caching node modules"
+      output_line "Caching node modules"
       cp -R node_modules $cache_dir
     fi
 
@@ -275,10 +275,10 @@ install_and_cache_deps() {
 }
 
 install_npm_deps() {
-  npm prune | indent
-  npm install --quiet --unsafe-perm --userconfig $build_dir/npmrc 2>&1 | indent
-  npm rebuild 2>&1 | indent
-  npm --unsafe-perm prune 2>&1 | indent
+  npm prune | output_indent
+  npm install --quiet --unsafe-perm --userconfig $build_dir/npmrc 2>&1 | output_indent
+  npm rebuild 2>&1 | output_indent
+  npm --unsafe-perm prune 2>&1 | output_indent
 }
 
 install_yarn_deps() {
@@ -294,7 +294,7 @@ install_bower_deps() {
   local bower_json=bower.json
 
   if [ -f $bower_json ]; then
-    info "Installing and caching bower components"
+    output_line "Installing and caching bower components"
 
     if [ -d $cache_dir/bower_components ]; then
       mkdir -p bower_components
@@ -322,7 +322,7 @@ run_compile() {
 
   if [ $has_clean = 0 ]; then
     mkdir -p $cache_dir/phoenix-static
-    info "Restoring cached assets"
+    output_line "Restoring cached assets"
     mkdir -p priv
     rsync -a -v --ignore-existing $cache_dir/phoenix-static/ priv/static
   fi
@@ -332,23 +332,23 @@ run_compile() {
   fi
 
   if [ -f $custom_compile ]; then
-    info "Running custom compile"
-    source_file $custom_compile 2>&1 | indent
+    output_line "Running custom compile"
+    source_file $custom_compile 2>&1 | output_indent
   else
-    info "Running default compile"
-    source ${build_pack_dir}/${compile} 2>&1 | indent
+    output_line "Running default compile"
+    source ${build_pack_dir}/${compile} 2>&1 | output_indent
   fi
 
   cd $phoenix_dir
 
   if [ $has_clean = 0 ]; then
-    info "Caching assets"
+    output_line "Caching assets"
     rsync -a --delete -v priv/static/ $cache_dir/phoenix-static
   fi
 }
 
 cache_versions() {
-  info "Caching versions for future builds"
+  output_line "Caching versions for future builds"
   echo `node --version` > $cache_dir/node-version
   echo `npm --version` > $cache_dir/npm-version
 }
@@ -362,14 +362,14 @@ finalize_node() {
 }
 
 write_profile() {
-  info "Creating runtime environment"
+  output_line "Creating runtime environment"
   mkdir -p $build_dir/.profile.d
   local export_line="export PATH=\"\$HOME/.heroku/node/bin:\$HOME/.heroku/yarn/bin:\$HOME/bin:\$HOME/$phoenix_relative_path/node_modules/.bin:\$PATH\""
   echo $export_line >> $build_dir/.profile.d/phoenix_static_buildpack_paths.sh
 }
 
 remove_node() {
-  info "Removing node and node_modules"
+  output_line "Removing node and node_modules"
   rm -rf $assets_dir/node_modules
   rm -rf $heroku_dir/node
 }
@@ -384,7 +384,7 @@ fail_bin_install() {
 }
 
 setup_phx_envvars() {
-  info "Setting up Phoenix environment variables"
+  output_line "Setting up Phoenix environment variables"
   mkdir -p $build_dir/.profile.d
 
   local phoenix_env_file=$build_dir/.profile.d/phoenix_static_buildpack_env.sh

--- a/lib/common.sh
+++ b/lib/common.sh
@@ -1,19 +1,3 @@
-info() {
-  #echo "`date +\"%M:%S\"`  $*"
-  echo "       $*"
-}
-
-indent() {
-  while read LINE; do
-    echo "       $LINE" || true
-  done
-}
-
-header() {
-  echo ""
-  echo "-----> $*"
-}
-
 file_contents() {
   if test -f $1; then
     echo "$(cat $1)"
@@ -23,7 +7,7 @@ file_contents() {
 }
 
 load_config() {
-  info "Loading config..."
+  output_line "Loading config..."
 
   local custom_config_file="${build_dir}/phoenix_static_buildpack.config"
 
@@ -33,8 +17,8 @@ load_config() {
   if [ -f $custom_config_file ]; then
     source_file $custom_config_file
   else
-    info "The config file phoenix_static_buildpack.config wasn't found"
-    info "Using the default config provided from the Phoenix static buildpack"
+    output_line "The config file phoenix_static_buildpack.config wasn't found"
+    output_line "Using the default config provided from the Phoenix static buildpack"
   fi
 
   fix_node_version
@@ -42,56 +26,56 @@ load_config() {
 
   phoenix_dir=$build_dir/$phoenix_relative_path
 
-  info "Detecting assets directory"
+  output_line "Detecting assets directory"
   if [ -f "$phoenix_dir/$assets_path/package.json" ]; then
     # Check phoenix custom sub-directory for package.json
-    info "* package.json found in custom directory"
+    output_line "* package.json found in custom directory"
   elif [ -f "$phoenix_dir/package.json" ]; then
-    info "* package.json found in root directory"
+    output_line "* package.json found in root directory"
     assets_path=.
   else
-    info "WARNING: no package.json detected in root nor custom directory"
-    info "* assuming assets are in /assets"
+    output_line "WARNING: no package.json detected in root nor custom directory"
+    output_line "* assuming assets are in /assets"
 
     assets_path=assets
   fi
 
   if [ -n "${phoenix_ex}" ]; then
-    info "Using mix namespace for phoenix tasks from config: ${phoenix_ex}"
+    output_line "Using mix namespace for phoenix tasks from config: ${phoenix_ex}"
   else
-    info "Detecting mix namespace for phoenix tasks"
+    output_line "Detecting mix namespace for phoenix tasks"
 
     phoenix_ex=phx
     if [ -f "${build_dir}/mix.lock" ]; then
       local phoenix_version=$(elixir lib/phoenix_version.exs "${build_dir}/mix.lock" 2>/dev/null)
       if [ -n "${phoenix_version}" ]; then
         if ! echo -e "${phoenix_version}\n1.3.0" | sort -V | head -n 1 | grep -q "^1.3.0$"; then
-          info "Detected Phoenix version ${phoenix_version}, which is prior to 1.3.0"
+          output_line "Detected Phoenix version ${phoenix_version}, which is prior to 1.3.0"
           phoenix_ex=phoenix
         fi
       else
-        info "WARNING: unable to detect version, assuming 1.3.0 or greater for '${phoenix_version}'"
+        output_line "WARNING: unable to detect version, assuming 1.3.0 or greater for '${phoenix_version}'"
       fi
     else
-      info "WARNING: no mix.lock detected, assuming 1.3.0 or greater"
+      output_line "WARNING: no mix.lock detected, assuming 1.3.0 or greater"
     fi
-    info "* Using mix namespace '${phoenix_ex}' for phoenix tasks"
+    output_line "* Using mix namespace '${phoenix_ex}' for phoenix tasks"
   fi
 
   assets_dir=$phoenix_dir/$assets_path
-  info "Will use phoenix configuration:"
-  info "* assets path ${assets_path}"
-  info "* mix tasks namespace ${phoenix_ex}"
+  output_line "Will use phoenix configuration:"
+  output_line "* assets path ${assets_path}"
+  output_line "* mix tasks namespace ${phoenix_ex}"
 
-  info "Will use the following versions:"
-  info "* Node ${node_version}"
+  output_line "Will use the following versions:"
+  output_line "* Node ${node_version}"
 }
 
 export_config_vars() {
   whitelist_regex=${2:-''}
   blacklist_regex=${3:-'^(PATH|GIT_DIR|CPATH|CPPATH|LD_PRELOAD|LIBRARY_PATH)$'}
   if [ -d "$env_dir" ]; then
-    info "Will export the following config vars:"
+    output_line "Will export the following config vars:"
     for e in $(ls $env_dir); do
       echo "$e" | grep -E "$whitelist_regex" | grep -vE "$blacklist_regex" &&
       export "$e=$(cat $env_dir/$e)"
@@ -109,7 +93,7 @@ export_mix_env() {
     fi
   fi
 
-  info "* MIX_ENV=${MIX_ENV}"
+  output_line "* MIX_ENV=${MIX_ENV}"
 }
 
 fix_node_version() {

--- a/lib/output_funcs.sh
+++ b/lib/output_funcs.sh
@@ -1,0 +1,56 @@
+# Outputs section heading
+#
+# Usage:
+#
+#     output_section "Application tasks"
+#
+output_section() {
+  local indentation="----->"
+  echo "${indentation} $1"
+}
+
+# Outputs log line
+#
+# Usage:
+#
+#     output_line "Cloning repository"
+#
+output_line() {
+  local spacing="      "
+  echo "${spacing} $1"
+}
+
+# Outputs a warning in red
+#
+# Usage:
+#
+#     output_warning "Something went wrong"
+#
+output_warning() {
+  local spacing="      "
+  echo -e "${spacing} \e[31m$1\e[0m"
+}
+
+# Outputs to stderr for debugging
+#
+# Usage:
+#
+#     output_stderr "Debug info"
+#
+output_stderr() {
+  # Outputs to stderr in case it is inside a function so it does not
+  # disturb the return value. Useful for debugging.
+  echo "$@" 1>&2;
+}
+
+# Pipe processor for indenting command output
+#
+# Usage:
+#
+#     command | output_indent
+#
+output_indent() {
+  while read LINE; do
+    echo "       $LINE" || true
+  done
+}

--- a/test/.test_support.sh
+++ b/test/.test_support.sh
@@ -1,53 +1,13 @@
 #!/usr/bin/env bash
 
-set -o pipefail   # don't ignore exit codes when piping output
+set -o pipefail
 
-ROOT_DIR=$(dirname "$SCRIPT_DIR")
-PASSED_ALL_TESTS=false
+REPO_NAME="gigalixir-buildpack-phoenix-static"
+source "$(dirname "${BASH_SOURCE[0]}")/test_framework.sh"
+
 build_pack_dir="${ROOT_DIR}"
-
-# make a temp dir for test files/directories
-TEST_DIR=$(mktemp -d -t gigalixir-buildpack-phoenix-static_XXXXXXXXXX)
-ECHO_CONTENT=()
-cleanup() {
-  rm -rf ${TEST_DIR}
-  if $PASSED_ALL_TESTS; then
-    /bin/echo -e "  \e[0;32mTest Suite PASSED\e[0m"
-  else
-    /bin/echo -e "  \e[0;31mFAILED\e[0m"
-  fi
-  exit
-}
-trap cleanup EXIT INT TERM
 
 # create directories for test
 assets_dir=${TEST_DIR}/assets_dir
 cache_dir=${TEST_DIR}/cache_dir
 mkdir -p ${assets_dir} ${cache_dir}
-
-
-# stub output functions to suppress noise in tests
-output_section() {
-  true
-}
-output_line() {
-  true
-}
-output_warning() {
-  true
-}
-output_indent() {
-  cat > /dev/null
-}
-
-# helper functions
-test() {
-  failed=false
-  ECHO_CONTENT=()
-  /bin/echo "  TEST: $@"
-}
-
-suite() {
-  failed=false
-  /bin/echo -e "\e[0;36mSUITE: $@\e[0m"
-}

--- a/test/.test_support.sh
+++ b/test/.test_support.sh
@@ -26,9 +26,18 @@ cache_dir=${TEST_DIR}/cache_dir
 mkdir -p ${assets_dir} ${cache_dir}
 
 
-# overridden functions
-info() {
+# stub output functions to suppress noise in tests
+output_section() {
   true
+}
+output_line() {
+  true
+}
+output_warning() {
+  true
+}
+output_indent() {
+  cat > /dev/null
 }
 
 # helper functions

--- a/test/test_framework.sh
+++ b/test/test_framework.sh
@@ -1,0 +1,60 @@
+#!/usr/bin/env bash
+#
+# Shared test framework for gigalixir buildpack repos.
+#
+# Prerequisites (must be set before sourcing):
+#   SCRIPT_DIR  - absolute path to the test/ directory
+#   REPO_NAME   - name used in the mktemp template
+#
+
+ROOT_DIR=$(dirname "$SCRIPT_DIR")
+PASSED_ALL_TESTS=false
+ECHO_CONTENT=()
+
+# make a temp dir for test files/directories
+TEST_DIR=$(mktemp -d -t "${REPO_NAME}_XXXXXXXXXX")
+
+cleanup() {
+  rm -rf ${TEST_DIR}
+  if $PASSED_ALL_TESTS; then
+    /bin/echo -e "  \e[0;32mTest Suite PASSED\e[0m"
+  else
+    /bin/echo -e "  \e[0;31mFAILED\e[0m"
+  fi
+  exit
+}
+trap cleanup EXIT INT TERM
+
+# stub output functions to suppress noise in tests
+output_section() {
+  true
+}
+output_line() {
+  true
+}
+output_warning() {
+  true
+}
+output_stderr() {
+  true
+}
+output_indent() {
+  cat > /dev/null
+}
+
+# helper functions
+test() {
+  reset_test
+  failed=false
+  ECHO_CONTENT=()
+  /bin/echo "  TEST: $@"
+}
+
+suite() {
+  failed=false
+  /bin/echo -e "\e[0;36mSUITE: $@\e[0m"
+}
+
+reset_test() {
+  true
+}


### PR DESCRIPTION
## Summary

Standardizes shared infrastructure across the 4 gigalixir buildpack repos (elixir, mix, phoenix-static, releases).

### Output functions (`lib/output_funcs.sh`)
- Extracts `output_section`, `output_line`, `output_warning`, `output_stderr`, and `output_indent` into a shared `lib/output_funcs.sh`
- Replaces inline definitions and legacy function names (`info`, `indent`, `header`) with the standardized versions
- The shared file is identical across all 4 repos

### Test framework (`test/test_framework.sh`)
- Extracts common test plumbing (cleanup/trap, output stubs, `test()`/`suite()`/`reset_test()` helpers) into a shared `test/test_framework.sh`
- Each repo's `test/.test_support.sh` is now a thin wrapper that sets repo-specific variables and sources the framework
- The framework file is identical across all 4 repos

### Makefile
- Adds a `Makefile` with a default `test` target that runs all executable test files
- Updates CI workflow to use `make test`

## Test plan
- [x] All tests pass locally via `make test` in each repo
- [x] CI passes on all 4 PRs