### PR TITLE
feat: buildpack exclusion based on envvar

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,7 @@ This buildpack is meant to be used with the [Heroku Buildpack for Elixir](https:
 * Can configure versions for Node and NPM
 * Auto-installs Bower deps if `bower.json` is in your app's root path
 * Caches Node, NPM modules and Bower components
+* Can be disabled without removing the buildpack via the `PHOENIX_STATIC_BUILDPACK__DISABLED` environment variable
 
 ## Usage
 
@@ -42,6 +43,19 @@ bundle install
 
 Finally, add the ruby buildpack to your `.buildpacks` file.
 Ask [Gigalixir Support](mailto:help@gigalixir.com) for any assistance.
+
+## Disabling the buildpack
+
+You can disable this buildpack without removing it from your `.buildpacks` file by
+setting the `PHOENIX_STATIC_BUILDPACK__DISABLED` environment variable to `1` or `true`.
+When set, detection will report that Phoenix was found but is disabled and the buildpack
+will be skipped:
+
+```bash
+gigalixir config:set PHOENIX_STATIC_BUILDPACK__DISABLED=true
+```
+
+To re-enable it, unset the variable or set it to any other value.
 
 ## Configuration
 

--- a/bin/detect
+++ b/bin/detect
@@ -4,8 +4,14 @@ mix_file_url="$1/mix.exs"
 
 if [ -f $mix_file_url ];
 then
-  echo "Phoenix"
-  exit 0
+  if [ "$PHOENIX_STATIC_BUILDPACK__DISABLED" == "1" ] || [ "$PHOENIX_STATIC_BUILDPACK__DISABLED" == "true" ];
+  then
+    echo "Phoenix detected, but disabled by PHOENIX_STATIC_BUILDPACK__DISABLED"
+    exit 1
+  else
+    echo "Phoenix"
+    exit 0
+  fi
 else
   exit 1
 fi

--- a/test/detect_test.sh
+++ b/test/detect_test.sh
@@ -25,6 +25,7 @@ suite "detect"
     EXIT_CODE=""
     ECHO_CONTENT=()
     touch $TEST_DIR/mix.exs
+    unset PHOENIX_STATIC_BUILDPACK__DISABLED
 
     source $SCRIPT_DIR/../bin/detect "$TEST_DIR"
 
@@ -44,6 +45,57 @@ suite "detect"
 
     [ "1" -eq "$EXIT_CODE" ]
     [ "${#ECHO_CONTENT[@]}" -eq 0 ]
+
+
+
+  test "mix.exs exists but disabled with 1 exits 1"
+
+    EXIT_CODE=""
+    ECHO_CONTENT=()
+    touch $TEST_DIR/mix.exs
+    PHOENIX_STATIC_BUILDPACK__DISABLED=1
+
+    source $SCRIPT_DIR/../bin/detect "$TEST_DIR"
+
+    [ "1" -eq "$EXIT_CODE" ]
+    [ "Phoenix detected, but disabled by PHOENIX_STATIC_BUILDPACK__DISABLED" == "${ECHO_CONTENT[0]}" ]
+
+    rm $TEST_DIR/mix.exs
+    unset PHOENIX_STATIC_BUILDPACK__DISABLED
+
+
+
+  test "mix.exs exists but disabled with true exits 1"
+
+    EXIT_CODE=""
+    ECHO_CONTENT=()
+    touch $TEST_DIR/mix.exs
+    PHOENIX_STATIC_BUILDPACK__DISABLED=true
+
+    source $SCRIPT_DIR/../bin/detect "$TEST_DIR"
+
+    [ "1" -eq "$EXIT_CODE" ]
+    [ "Phoenix detected, but disabled by PHOENIX_STATIC_BUILDPACK__DISABLED" == "${ECHO_CONTENT[0]}" ]
+
+    rm $TEST_DIR/mix.exs
+    unset PHOENIX_STATIC_BUILDPACK__DISABLED
+
+
+
+  test "mix.exs exists and disabled set to other value outputs Phoenix and exits 0"
+
+    EXIT_CODE=""
+    ECHO_CONTENT=()
+    touch $TEST_DIR/mix.exs
+    PHOENIX_STATIC_BUILDPACK__DISABLED=false
+
+    source $SCRIPT_DIR/../bin/detect "$TEST_DIR"
+
+    [ "0" -eq "$EXIT_CODE" ]
+    [ "Phoenix" == "${ECHO_CONTENT[0]}" ]
+
+    rm $TEST_DIR/mix.exs
+    unset PHOENIX_STATIC_BUILDPACK__DISABLED
 
 
 


### PR DESCRIPTION
Allow for this buildpack to be skipped if `PHOENIX_STATIC_BUILDPACK__DISABLED` is set to "1" or "true".
