### PR TITLE
feat: skip compilation based on envvar

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,8 +48,9 @@ Ask [Gigalixir Support](mailto:help@gigalixir.com) for any assistance.
 
 You can disable this buildpack without removing it from your `.buildpacks` file by
 setting the `PHOENIX_STATIC_BUILDPACK__DISABLED` environment variable to `1` or `true`.
-When set, detection will report that Phoenix was found but is disabled and the buildpack
-will be skipped:
+When set, detection reports that Phoenix was found but is disabled (and exits non-zero),
+and the compile step short-circuits early with a message and succeeds without doing any
+work — so the buildpack is skipped regardless of whether detection runs:
 
 ```bash
 gigalixir config:set PHOENIX_STATIC_BUILDPACK__DISABLED=true

--- a/bin/compile
+++ b/bin/compile
@@ -22,6 +22,14 @@ heroku_dir=$build_dir/.heroku
 source ${build_pack_dir}/lib/output_funcs.sh
 source ${build_pack_dir}/lib/common.sh
 source ${build_pack_dir}/lib/build.sh
+source ${build_pack_dir}/lib/disabled.sh
+
+
+# Skip the buildpack entirely if disabled, before doing any work.
+if buildpack_disabled_in_env_dir "$env_dir"; then
+  output_section "Phoenix static buildpack disabled by PHOENIX_STATIC_BUILDPACK__DISABLED, skipping"
+  exit 0
+fi
 
 
 output_section "Loading configuration and environment"

--- a/bin/detect
+++ b/bin/detect
@@ -1,10 +1,13 @@
 #!/usr/bin/env bash
 
+bin_dir=$(cd $(dirname $0); pwd)
+source "${bin_dir}/../lib/disabled.sh"
+
 mix_file_url="$1/mix.exs"
 
 if [ -f $mix_file_url ];
 then
-  if [ "$PHOENIX_STATIC_BUILDPACK__DISABLED" == "1" ] || [ "$PHOENIX_STATIC_BUILDPACK__DISABLED" == "true" ];
+  if buildpack_disabled_value "$PHOENIX_STATIC_BUILDPACK__DISABLED";
   then
     echo "Phoenix detected, but disabled by PHOENIX_STATIC_BUILDPACK__DISABLED"
     exit 1

--- a/lib/disabled.sh
+++ b/lib/disabled.sh
@@ -1,0 +1,19 @@
+#!/usr/bin/env bash
+
+# Name of the environment variable that disables this buildpack.
+PHOENIX_STATIC_BUILDPACK_DISABLED_VAR="PHOENIX_STATIC_BUILDPACK__DISABLED"
+
+# Returns success (0) when the given value means the buildpack is disabled.
+buildpack_disabled_value() {
+  [ "$1" = "1" ] || [ "$1" = "true" ]
+}
+
+# Returns success (0) when the disable env var is present in the given env_dir
+# and its value disables the buildpack. Heroku-style env_dir: a file named
+# after the variable whose contents are the value.
+buildpack_disabled_in_env_dir() {
+  local env_dir="$1"
+  local var_file="${env_dir}/${PHOENIX_STATIC_BUILDPACK_DISABLED_VAR}"
+
+  [ -f "$var_file" ] && buildpack_disabled_value "$(cat "$var_file")"
+}

--- a/test/disabled_test.sh
+++ b/test/disabled_test.sh
@@ -1,0 +1,72 @@
+#!/usr/bin/env bash
+
+set -e
+
+SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )"
+source $SCRIPT_DIR/.test_support.sh
+
+# include source file
+source $SCRIPT_DIR/../lib/disabled.sh
+
+env_dir=${TEST_DIR}/env_dir
+mkdir -p ${env_dir}
+var_file=${env_dir}/PHOENIX_STATIC_BUILDPACK__DISABLED
+
+# TESTS
+######################
+suite "disabled"
+
+
+  test "buildpack_disabled_value true for '1'"
+
+    buildpack_disabled_value "1"
+
+
+
+  test "buildpack_disabled_value true for 'true'"
+
+    buildpack_disabled_value "true"
+
+
+
+  test "buildpack_disabled_value false for other values"
+
+    ! buildpack_disabled_value "false"
+    ! buildpack_disabled_value "0"
+    ! buildpack_disabled_value ""
+    ! buildpack_disabled_value "yes"
+
+
+
+  test "buildpack_disabled_in_env_dir false when file absent"
+
+    rm -f $var_file
+    ! buildpack_disabled_in_env_dir "$env_dir"
+
+
+
+  test "buildpack_disabled_in_env_dir true when file holds '1'"
+
+    printf '1' > $var_file
+    buildpack_disabled_in_env_dir "$env_dir"
+    rm -f $var_file
+
+
+
+  test "buildpack_disabled_in_env_dir true when file holds 'true'"
+
+    printf 'true' > $var_file
+    buildpack_disabled_in_env_dir "$env_dir"
+    rm -f $var_file
+
+
+
+  test "buildpack_disabled_in_env_dir false when file holds other value"
+
+    printf 'false' > $var_file
+    ! buildpack_disabled_in_env_dir "$env_dir"
+    rm -f $var_file
+
+
+
+PASSED_ALL_TESTS=true


### PR DESCRIPTION
Under some circumstances #28 is not enough to skip compilation.  This PR adds a compilation skip when the envvar is provided.
