### PR TITLE
fix: pnpm v11 releases

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,7 +10,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v6
 
     - name: run tests
       run: make test

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,107 @@
+name: Release
+
+# Cut a GitHub Release on every merge to main, versioned from conventional
+# commits since the last tag (feat: -> minor, fix: -> patch,
+# BREAKING CHANGE / ! -> major). Merges whose commits don't match any of those
+# (docs/chore/refactor/test/ci) produce no tag and no release.
+#
+# First-party only: git + the GitHub CLI (gh, preinstalled on the runner) +
+# actions/checkout (GitHub's own org). No third-party actions. The one piece
+# with no official tool -- picking the semver bump from commit messages -- is
+# the small shell block below.
+#
+# Relies on at least one existing semver tag (e.g. v1.0.0) as a baseline; with
+# no tags present it seeds the first release at v1.0.0.
+on:
+  push:
+    branches:
+      - main
+
+# Never run two releases concurrently; let an in-flight one finish.
+concurrency:
+  group: release
+  cancel-in-progress: false
+
+permissions:
+  contents: write # push tags and create releases
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          fetch-depth: 0 # full history + tags so we can find the previous tag
+          fetch-tags: true
+
+      - name: Compute next version from conventional commits
+        id: version
+        run: |
+          set -euo pipefail
+
+          last_tag=$(git tag --list 'v*' --sort=-v:refname | head -n1)
+
+          # No tags yet: seed the first release.
+          if [ -z "$last_tag" ]; then
+            echo "No existing tags; seeding initial release v1.0.0"
+            {
+              echo "release=true"
+              echo "tag=v1.0.0"
+            } >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          range="${last_tag}..HEAD"
+          subjects=$(git log --format='%s' "$range")
+          bodies=$(git log --format='%B' "$range")
+
+          # Highest-precedence bump wins: major > minor > patch.
+          if printf '%s\n' "$bodies"   | grep -qE 'BREAKING CHANGE' \
+          || printf '%s\n' "$subjects" | grep -qE '^[a-z]+(\(.+\))?!:'; then
+            bump=major
+          elif printf '%s\n' "$subjects" | grep -qE '^feat(\(.+\))?:'; then
+            bump=minor
+          elif printf '%s\n' "$subjects" | grep -qE '^fix(\(.+\))?:'; then
+            bump=patch
+          else
+            echo "No releasable commits since ${last_tag}; skipping."
+            echo "release=false" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          IFS=. read -r major minor patch <<< "${last_tag#v}"
+          case "$bump" in
+            major) major=$((major + 1)); minor=0; patch=0 ;;
+            minor) minor=$((minor + 1)); patch=0 ;;
+            patch) patch=$((patch + 1)) ;;
+          esac
+
+          next="v${major}.${minor}.${patch}"
+          echo "Next version: ${next} (${bump}, from ${last_tag})"
+          {
+            echo "release=true"
+            echo "tag=${next}"
+          } >> "$GITHUB_OUTPUT"
+
+      - name: Create tag and release
+        if: steps.version.outputs.release == 'true'
+        env:
+          GH_TOKEN: ${{ github.token }}
+          TAG: ${{ steps.version.outputs.tag }}
+        run: |
+          set -euo pipefail
+
+          # Idempotency guard: bail if a re-run would clash with an existing tag.
+          if git ls-remote --exit-code --tags origin "refs/tags/${TAG}" >/dev/null 2>&1; then
+            echo "Tag ${TAG} already exists on origin; nothing to do."
+            exit 0
+          fi
+
+          git config user.name  "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git tag -a "$TAG" -m "$TAG"
+          git push origin "$TAG"
+
+          # --generate-notes uses GitHub's built-in (first-party) notes generator.
+          gh release create "$TAG" --title "$TAG" --generate-notes --target "$GITHUB_SHA"

--- a/lib/build.sh
+++ b/lib/build.sh
@@ -228,15 +228,30 @@ install_pnpm() {
   fi
 
   echo "Downloading and installing pnpm $pnpm_version..."
-  local download_url="https://github.com/pnpm/pnpm/releases/download/v$pnpm_version/pnpm-linux-x64"
 
-  local code=$(curl -w "%{http_code}" -L "$download_url" --silent --fail --retry 5 --retry-max-time 15 -o /tmp/pnpm --write-out "%{http_code}")
+  # pnpm changed its release packaging at v11.0.0:
+  #   <= 10 ships a single self-contained binary asset (pnpm-linux-x64)
+  #   >= 11 ships a gzipped tarball (pnpm-linux-x64.tar.gz) with the `pnpm`
+  #         binary plus a `dist/` dir at the root, which must be kept together.
+  local major="${pnpm_version%%.*}"
+  local asset="pnpm-linux-x64"
+  [ "$major" -ge 11 ] && asset="pnpm-linux-x64.tar.gz"
+
+  local download_url="https://github.com/pnpm/pnpm/releases/download/v$pnpm_version/$asset"
+  local code=$(curl -w "%{http_code}" -L "$download_url" --silent --fail --retry 5 --retry-max-time 15 -o "/tmp/$asset" --write-out "%{http_code}")
   if [ "$code" != "200" ]; then
     echo "Unable to download pnpm: $code" && return 1
   fi
+
+  rm -rf "$dir"
   mkdir -p "$dir"
-  mv /tmp/pnpm "$dir/pnpm"
+  if [ "$major" -ge 11 ]; then
+    tar xzf "/tmp/$asset" -C "$dir"
+  else
+    mv "/tmp/$asset" "$dir/pnpm"
+  fi
   chmod +x "$dir/pnpm"
+
   PATH=$dir:$PATH
   echo "Installed pnpm $(pnpm --version)"
 }

--- a/test/install_pnpm_test.sh
+++ b/test/install_pnpm_test.sh
@@ -1,0 +1,94 @@
+#!/usr/bin/env bash
+
+set -e
+
+SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )"
+source $SCRIPT_DIR/.test_support.sh
+
+# include source file
+source $SCRIPT_DIR/../lib/build.sh
+
+# Build a fake pnpm >= 11 release tarball at $1 reporting version $2.
+# Mirrors the real layout: `pnpm` binary + `dist/` at the tarball root.
+make_pnpm_tarball() {
+  local out="$1" ver="$2"
+  local stage=$(mktemp -d)
+  printf '#!/bin/sh\necho %s\n' "$ver" > "$stage/pnpm"
+  chmod +x "$stage/pnpm"
+  mkdir -p "$stage/dist"
+  touch "$stage/dist/pnpm.cjs"
+  tar czf "$out" -C "$stage" pnpm dist
+  rm -rf "$stage"
+}
+
+# Stub curl to model GitHub's actual asset availability:
+#   pnpm >= 11 publishes only `pnpm-linux-x64.tar.gz` (a gzipped tarball)
+#   pnpm <= 10 publishes only `pnpm-linux-x64` (a raw self-contained binary)
+# Any other request 404s, exactly as GitHub would.
+curl() {
+  local url="" out=""
+  while [ $# -gt 0 ]; do
+    case "$1" in
+      -o) out="$2"; shift 2;;
+      http*) url="$1"; shift;;
+      *) shift;;
+    esac
+  done
+
+  local asset="${url##*/}"
+  local ver="${url%/*}"; ver="${ver##*/v}"
+  local major="${ver%%.*}"
+
+  if [ "$major" -ge 11 ]; then
+    if [ "$asset" = "pnpm-linux-x64.tar.gz" ]; then
+      make_pnpm_tarball "$out" "$ver"; printf '200'
+    else
+      printf '404'
+    fi
+  else
+    if [ "$asset" = "pnpm-linux-x64" ]; then
+      printf '#!/bin/sh\necho %s\n' "$ver" > "$out"; chmod +x "$out"; printf '200'
+    else
+      printf '404'
+    fi
+  fi
+}
+
+# silence install messages
+echo() { true; }
+
+# TESTS
+######################
+suite "install_pnpm"
+
+
+  test "installs pnpm >= 11 from the gzipped tarball asset"
+
+    dir=$TEST_DIR/pnpm_v11
+    pnpm_version=11.0.9
+
+    install_pnpm "$dir"
+
+    [ -x "$dir/pnpm" ]
+    [ -d "$dir/dist" ]
+    [ "11.0.9" == "$("$dir/pnpm" --version)" ]
+
+    rm -rf "$dir"
+
+
+
+  test "installs pnpm <= 10 from the raw binary asset"
+
+    dir=$TEST_DIR/pnpm_v10
+    pnpm_version=10.4.1
+
+    install_pnpm "$dir"
+
+    [ -x "$dir/pnpm" ]
+    [ "10.4.1" == "$("$dir/pnpm" --version)" ]
+
+    rm -rf "$dir"
+
+
+
+PASSED_ALL_TESTS=true


### PR DESCRIPTION
pnpm 11.0.0 changed the download path for releases from a direct download to a tarball

This pr addresses that change, plus adds a workflow to automatically update the version on merge to main, which will trigger a release.

- **fix: pnpm v11 download change**
- **chore: add a workflow for versioning on merge**
