### PR TITLE
fix: silent node download errors

### DIFF
--- a/lib/build.sh
+++ b/lib/build.sh
@@ -20,13 +20,50 @@ load_previous_npm_node_versions() {
   fi
 }
 
+# fetches $1 on stdout, retrying up to node_lookup_attempts times
+#
+# curl's own --retry only covers transport errors and a handful of 5xx codes, so
+# on its own it will happily hand back a 404 body or the empty response a stale
+# CDN edge can serve. --fail turns bad statuses into a non-zero exit, and an
+# empty body counts as a failed attempt, so both get retried here instead of
+# silently flowing downstream as if they were real content.
+fetch_url() {
+  local url="$1"
+  local attempts=${node_lookup_attempts:-3}
+  local delay=${node_lookup_delay:-1}
+  local attempt=1
+  local body=""
+
+  while [ $attempt -le $attempts ]; do
+    if body=$(curl "$url" --silent --show-error --fail --get -L --retry 5 --retry-max-time 15) && [ -n "$body" ]; then
+      echo "$body"
+      return 0
+    fi
+
+    # to stderr: this function's stdout is the response body the caller captures,
+    # so anything logged there would be swallowed or spliced into the content
+    output_line "Failed to fetch ${url} (attempt ${attempt} of ${attempts})" >&2
+
+    if [ $attempt -lt $attempts ]; then
+      sleep $delay
+    fi
+
+    attempt=$((attempt + 1))
+  done
+
+  return 1
+}
+
 # on success, node_version will be in X.Y.Z format, node_url and node_sha will be set
 # on failure, this will exit non-zero
 resolve_node_version() {
   echo "Resolving node version $node_version..."
-  
+
   local base_url="https://nodejs.org/dist"
   local lookup_url=""
+
+  node_url=""
+  node_sha=""
 
   case $node_version in
     ""|latest)
@@ -40,18 +77,22 @@ resolve_node_version() {
       ;;
   esac
 
+  local listing=""
   local node_file=""
-  if node_file=$(curl --silent --get -L --retry 5 --retry-max-time 15 $lookup_url | grep -oE  '"[^"]*node-v[0-9]+.[0-9]+.[0-9]+-linux-x64.tar.gz"')
-  then
-    node_version=$(echo "$node_file" | sed -E 's/.*node-v([0-9]+\.[0-9]+\.[0-9]+).*/\1/')
-    if echo "${node_file}" | grep -q "/"; then
-      node_file=$(echo "${node_file}" | sed -e 's/\/dist//')
-      node_url="${base_url}${node_file//\"/}"
-    else
-      node_url="${base_url}/v${node_version}/${node_file//\"/}"
-    fi
+  if listing=$(fetch_url "${lookup_url}"); then
+    node_file=$(echo "$listing" | grep -oE '"[^"]*node-v[0-9]+.[0-9]+.[0-9]+-linux-x64.tar.gz"' | head -n 1) || true
+  fi
+
+  if [ -z "$node_file" ]; then
+    fail_bin_install node "$node_version" "Unable to resolve version from ${lookup_url}"
+  fi
+
+  node_version=$(echo "$node_file" | sed -E 's/.*node-v([0-9]+\.[0-9]+\.[0-9]+).*/\1/')
+  if echo "${node_file}" | grep -q "/"; then
+    node_file=$(echo "${node_file}" | sed -e 's/\/dist//')
+    node_url="${base_url}${node_file//\"/}"
   else
-    fail_bin_install node $node_version "Unable to resolve version"
+    node_url="${base_url}/v${node_version}/${node_file//\"/}"
   fi
 
   # set the cache locations
@@ -59,9 +100,20 @@ resolve_node_version() {
   cached_sha=$cache_dir/SHA256SUM-node-v$node_version
 
   # get the corresponding checksum
-  local sha_url=${lookup_url}SHASUMS256.txt
-  node_sha=$(curl --silent --get -L --retry 5 --retry-max-time 15 $sha_url | grep -E "node-v${node_version}-linux-x64.tar.gz" | awk '{print $1}')
-  if [ ! -z "$node_sha" ]; then
+  #
+  # An unverifiable download is not worth installing, so no checksum is a hard
+  # failure. It has to be a loud one: under `set -o errexit -o pipefail` the
+  # unguarded lookup this replaces took the whole build down with no output at
+  # all whenever nodejs.org served a 404 or a stale response.
+  local sha_url="${lookup_url}SHASUMS256.txt"
+  local shasums=""
+  if shasums=$(fetch_url "${sha_url}"); then
+    node_sha=$(echo "$shasums" | grep -E "node-v${node_version}-linux-x64.tar.gz" | awk '{print $1}' | head -n 1) || true
+  fi
+
+  if [ -z "$node_sha" ]; then
+    fail_bin_install node "$node_version" "Unable to fetch a checksum from ${sha_url}"
+  else
     echo "$node_sha ${cached_node}" > $cached_sha
   fi
 }

--- a/test/resolve_node_versions_test.sh
+++ b/test/resolve_node_versions_test.sh
@@ -8,16 +8,106 @@ source $SCRIPT_DIR/.test_support.sh
 # include source file
 source $SCRIPT_DIR/../lib/build.sh
 
+# bin/compile runs under `errexit` *and* `pipefail`, and that combination is what
+# turned a failed lookup into a build that aborted with no output at all. Keep both
+# on here so a regression fails the suite instead of hiding behind a relaxed shell.
+set -o errexit
+set -o pipefail
+
+# no waiting between retries
+node_lookup_delay=0
+
+# the framework silences log output, but these tests assert on what actually
+# reaches the build log, so put the real implementation back
+output_line() {
+  echo "       $1"
+}
+
 # override functions used
 fail_bin_install() {
   failed=true
+  FAIL_REASON="$3"
+  return 1
+}
+
+# Stub nodejs.org. LISTING_STATUS and SHASUMS_STATUS model what each endpoint
+# returns. Every request is logged to CURL_LOG so tests can count retries, a file
+# rather than a variable because fetch_url calls curl inside a command
+# substitution and a subshell's variables die with it.
+CURL_LOG=$TEST_DIR/curl_calls
+
+curl() {
+  local url=""
+  while [ $# -gt 0 ]; do
+    case "$1" in
+      http*) url="$1";;
+    esac
+    shift
+  done
+
+  echo "$url" >> $CURL_LOG
+
+  case "$url" in
+    */SHASUMS256.txt)
+      case "$SHASUMS_STATUS" in
+        # the published checksum file, one line per asset
+        ok)
+          echo "1111111111111111111111111111111111111111111111111111111111111111  node-v${SERVED_VERSION}-linux-x64.tar.xz"
+          echo "2222222222222222222222222222222222222222222222222222222222222222  node-v${SERVED_VERSION}-linux-x64.tar.gz"
+          ;;
+        # a CDN edge still serving the previous release's checksums
+        stale)
+          echo "3333333333333333333333333333333333333333333333333333333333333333  node-v0.0.1-linux-x64.tar.gz"
+          ;;
+        # 200 with an empty body
+        empty) true;;
+        # 404 or a transport error, with --fail curl exits non-zero
+        error) return 22;;
+      esac
+      ;;
+    *)
+      case "$LISTING_STATUS" in
+        ok)
+          echo "<a href=\"/dist/latest/node-v${SERVED_VERSION}-linux-arm64.tar.gz\">node-v${SERVED_VERSION}-linux-arm64.tar.gz</a>"
+          echo "<a href=\"/dist/latest/node-v${SERVED_VERSION}-linux-x64.tar.gz\">node-v${SERVED_VERSION}-linux-x64.tar.gz</a>"
+          ;;
+        # a listing with no hrefs, as some mirrors serve
+        unqualified)
+          echo "<a href=\"node-v${SERVED_VERSION}-linux-x64.tar.gz\">node-v${SERVED_VERSION}-linux-x64.tar.gz</a>"
+          ;;
+        # fails the first attempt, serves the listing on the retry
+        flaky)
+          if [ 1 -eq $(grep -c -F -x -- "$url" $CURL_LOG) ]; then
+            return 22
+          fi
+          echo "<a href=\"/dist/latest/node-v${SERVED_VERSION}-linux-x64.tar.gz\">node-v${SERVED_VERSION}-linux-x64.tar.gz</a>"
+          ;;
+        error) return 22;;
+      esac
+      ;;
+  esac
+}
+
+# reset the fake nodejs.org before each test
+reset_test() {
+  SERVED_VERSION=20.8.1
+  LISTING_STATUS=ok
+  SHASUMS_STATUS=ok
+  FAIL_REASON=""
+  node_url=""
+  node_sha=""
+  rm -f $CURL_LOG
+  rm -f $cache_dir/SHA256SUM-node-*
+}
+
+# count the requests made to a given url
+curl_calls_to() {
+  grep -c -F -x -- "$1" $CURL_LOG || true
 }
 
 # TESTS
 ######################
 suite "resolve_node_versions"
-  #disable pipefail for these tests
-  set +o pipefail
 
 
   test "node version specified with 'vX.Y.Z' format"
@@ -27,22 +117,12 @@ suite "resolve_node_versions"
     resolve_node_version > /dev/null
 
     [ "20.8.1" == "$node_version" ]
-    [ ! -z "$node_url" ]
-    [ ! -z "$node_sha" ]
+    [ "https://nodejs.org/dist/latest/node-v20.8.1-linux-x64.tar.gz" == "$node_url" ]
+    [ "2222222222222222222222222222222222222222222222222222222222222222" == "$node_sha" ]
     [ ! -z "$cached_node" ]
     [ ! -z "$cached_sha" ]
     [ -e $cached_sha ]
     ! $failed
-
-
-
-  test "unknown node version specified"
-
-    node_version=v0.0.0
-
-    resolve_node_version > /dev/null
-
-    $failed
 
 
 
@@ -59,25 +139,126 @@ suite "resolve_node_versions"
 
   test "node version specified with 'latest' string"
 
+    SERVED_VERSION=26.6.0
     node_version=latest
 
     resolve_node_version > /dev/null
 
-    [ ! -z "$node_version" ]
-    [ "latest" != "$node_version" ]
+    [ "26.6.0" == "$node_version" ]
     ! $failed
-    LATEST=$node_version
 
 
 
   test "node version specified with empty string"
 
+    SERVED_VERSION=26.6.0
     node_version=""
 
     resolve_node_version > /dev/null
 
-    [ ! -z "$node_version" ]
-    [ "$LATEST" == "$node_version" ]
+    [ "26.6.0" == "$node_version" ]
+    ! $failed
+
+
+
+  test "listing without a fully qualified href"
+
+    LISTING_STATUS=unqualified
+    node_version=20.8.1
+
+    resolve_node_version > /dev/null
+
+    [ "https://nodejs.org/dist/v20.8.1/node-v20.8.1-linux-x64.tar.gz" == "$node_url" ]
+    ! $failed
+
+
+
+  test "unknown node version specified"
+
+    LISTING_STATUS=error
+    node_version=v0.0.0
+
+    resolve_node_version > /dev/null 2>&1 || true
+
+    $failed
+    echo "$FAIL_REASON" | grep -q "https://nodejs.org/dist/v0.0.0/"
+
+
+
+  test "version lookup is retried before failing"
+
+    LISTING_STATUS=error
+    node_version=v0.0.0
+
+    resolve_node_version > /dev/null 2>&1 || true
+
+    [ 3 -eq $(curl_calls_to "https://nodejs.org/dist/v0.0.0/") ]
+    $failed
+
+
+
+  test "unavailable checksum fails with an error message"
+
+    SHASUMS_STATUS=error
+    node_version=20.8.1
+
+    resolve_node_version > /dev/null 2>&1 || true
+
+    $failed
+    echo "$FAIL_REASON" | grep -q "https://nodejs.org/dist/v20.8.1/SHASUMS256.txt"
+    [ ! -e $cached_sha ]
+
+
+
+  test "checksum lookup is retried before failing"
+
+    SHASUMS_STATUS=error
+    node_version=20.8.1
+
+    resolve_node_version > /dev/null 2>&1 || true
+
+    [ 3 -eq $(curl_calls_to "https://nodejs.org/dist/v20.8.1/SHASUMS256.txt") ]
+    $failed
+
+
+
+  test "checksums for another version fail rather than install unverified"
+
+    SHASUMS_STATUS=stale
+    node_version=20.8.1
+
+    resolve_node_version > /dev/null 2>&1 || true
+
+    [ -z "$node_sha" ]
+    [ ! -e $cached_sha ]
+    $failed
+
+
+
+  test "empty checksum response fails rather than install unverified"
+
+    SHASUMS_STATUS=empty
+    node_version=20.8.1
+
+    resolve_node_version > /dev/null 2>&1 || true
+
+    [ -z "$node_sha" ]
+    $failed
+
+
+
+  # fetch_url's stdout is the response body its caller captures, so a retry notice
+  # logged there would vanish from the build log and splice itself into the content
+  test "retry notices reach the build log without corrupting the response"
+
+    LISTING_STATUS=flaky
+    node_version=20.8.1
+
+    resolve_node_version > $TEST_DIR/build_log 2>&1
+
+    grep -q "Failed to fetch https://nodejs.org/dist/v20.8.1/ (attempt 1 of 3)" $TEST_DIR/build_log
+    [ "https://nodejs.org/dist/latest/node-v20.8.1-linux-x64.tar.gz" == "$node_url" ]
+    [ 2 -eq $(curl_calls_to "https://nodejs.org/dist/v20.8.1/") ]
     ! $failed
 
 


### PR DESCRIPTION
Failure to download the SHA for a node version resulted in silent abort in the build process.

This branch rectifies this with multiple retries and an information error message when the retries fail.