### PR TITLE
feat: read node version from .tool-versions

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ This buildpack is meant to be used with the [Heroku Buildpack for Elixir](https:
 * **Easy configuration** with `phoenix_static_buildpack.config` file
 * Automatically sets `DATABASE_URL`
 * If your app doesn't have a Procfile, default web task `mix phx.server` will be run
-* Can configure versions for Node and NPM
+* Can configure versions for Node and NPM, including the `nodejs` entry in an asdf `.tool-versions` file
 * Auto-installs Bower deps if `bower.json` is in your app's root path
 * Caches Node, NPM modules and Bower components
 * Can be disabled without removing the buildpack via the `PHOENIX_STATIC_BUILDPACK__DISABLED` environment variable
@@ -63,6 +63,20 @@ To re-enable it, unset the variable or set it to any other value.
 Create a `phoenix_static_buildpack.config` file in your app's root dir if you want to override the defaults. The file's syntax is bash.
 
 If you don't specify a config option, then the default option from the buildpack's [`phoenix_static_buildpack.config`](https://github.com/gigalixir/gigalixir-buildpack-phoenix-static/blob/main/phoenix_static_buildpack.config) file will be used.
+
+### Node version from `.tool-versions`
+
+If your app has an asdf [`.tool-versions`](https://asdf-vm.com/manage/configuration.html) file in its root dir, the `nodejs` entry is used as the Node version:
+
+```
+erlang 27.2.2
+elixir 1.17.3-otp-27
+nodejs 22.19.0
+```
+
+This is the same file the [Elixir buildpack](https://github.com/gigalixir/gigalixir-buildpack-elixir) reads its `erlang` and `elixir` versions from, so a single file can pin every version your app builds with.
+
+An explicit `node_version` in `phoenix_static_buildpack.config` still takes precedence, and asdf aliases (`lts/jod`, `system`, ...) are ignored with a warning since only an explicit version can be resolved.
 
 
 __Here's a full config file with all available options:__

--- a/lib/common.sh
+++ b/lib/common.sh
@@ -6,6 +6,19 @@ file_contents() {
   fi
 }
 
+# reads a package's version out of an asdf .tool-versions file, empty if unset
+#
+# Mirrors extract_asdf_version in gigalixir-buildpack-elixir, which reads the
+# erlang and elixir entries from this same file.
+extract_asdf_version() {
+  local file="${build_dir}/.tool-versions"
+  local package=$1
+
+  if [ -f $file ]; then
+    grep "^$package" $file | tail -n 1 | awk '{print $2}' || true
+  fi
+}
+
 load_config() {
   output_line "Loading config..."
 
@@ -13,6 +26,20 @@ load_config() {
 
   # Source for default versions file from buildpack first
   source "${build_pack_dir}/phoenix_static_buildpack.config"
+
+  # .tool-versions sits between the buildpack defaults and the app's own config
+  # file, so it beats the default but an explicit node_version still wins.
+  local asdf_node_version=$(extract_asdf_version "nodejs")
+  if [ -n "${asdf_node_version}" ]; then
+    # asdf also accepts aliases such as `lts/jod` and `system`, which mean nothing
+    # here and which fix_node_version would quietly reduce to the newest release
+    if echo "${asdf_node_version}" | grep -qE '[0-9]'; then
+      output_line "Detected nodejs ${asdf_node_version} in .tool-versions"
+      node_version=${asdf_node_version}
+    else
+      output_line "WARNING: ignoring unsupported nodejs version '${asdf_node_version}' from .tool-versions"
+    fi
+  fi
 
   if [ -f $custom_config_file ]; then
     source_file $custom_config_file

--- a/test/common_test.sh
+++ b/test/common_test.sh
@@ -218,6 +218,96 @@ suite "load_config"
 
 
 
+  test "reads node version from .tool-versions"
+
+    build_dir=$TEST_DIR/build_asdf
+    mkdir -p $build_dir
+    echo "erlang 27.2.2
+elixir 1.17.3-otp-27
+nodejs 22.19.0" > $build_dir/.tool-versions
+
+    load_config > /dev/null
+
+    [ "22.19.0" == "$node_version" ]
+
+    rm -rf $build_dir
+
+
+
+  test "custom config overrides .tool-versions"
+
+    build_dir=$TEST_DIR/build_asdf_and_cfg
+    mkdir -p $build_dir
+    echo "nodejs 22.19.0" > $build_dir/.tool-versions
+    echo 'node_version=20.0.0' > $build_dir/phoenix_static_buildpack.config
+
+    load_config > /dev/null
+
+    [ "20.0.0" == "$node_version" ]
+
+    rm -rf $build_dir
+
+
+
+  test "keeps the default when .tool-versions has no nodejs entry"
+
+    build_dir=$TEST_DIR/build_asdf_unrelated
+    mkdir -p $build_dir
+    echo "erlang 27.2.2
+elixir 1.17.3-otp-27" > $build_dir/.tool-versions
+
+    load_config > /dev/null
+
+    # the buildpack default is node_version=latest, which fix_node_version empties
+    [ -z "$node_version" ]
+
+    rm -rf $build_dir
+
+
+
+  test "uses the last nodejs entry in .tool-versions"
+
+    build_dir=$TEST_DIR/build_asdf_repeated
+    mkdir -p $build_dir
+    echo "nodejs 20.0.0
+nodejs 22.19.0" > $build_dir/.tool-versions
+
+    load_config > /dev/null
+
+    [ "22.19.0" == "$node_version" ]
+
+    rm -rf $build_dir
+
+
+
+  test "ignores an asdf alias in .tool-versions"
+
+    build_dir=$TEST_DIR/build_asdf_alias
+    mkdir -p $build_dir
+    echo "nodejs lts/jod" > $build_dir/.tool-versions
+
+    load_config > /dev/null
+
+    [ -z "$node_version" ]
+
+    rm -rf $build_dir
+
+
+
+  test "tolerates .tool-versions without a trailing newline"
+
+    build_dir=$TEST_DIR/build_asdf_no_newline
+    mkdir -p $build_dir
+    printf "erlang 27.2.2\nnodejs 22.19.0" > $build_dir/.tool-versions
+
+    load_config > /dev/null
+
+    [ "22.19.0" == "$node_version" ]
+
+    rm -rf $build_dir
+
+
+
   test "detects assets path when package.json in root"
 
     build_dir=$TEST_DIR/build_assets_root


### PR DESCRIPTION
## What

Reads the `nodejs` entry from an asdf `.tool-versions` file in the app root and uses it as `node_version`.

```
erlang 27.2.2
elixir 1.17.3-otp-27
nodejs 22.19.0
```

## Why

The [Elixir buildpack](https://github.com/gigalixir/gigalixir-buildpack-elixir) already reads `erlang` and `elixir` from this file, so apps reasonably assume the `nodejs` line works the same way. It didn't — this buildpack only ever read `phoenix_static_buildpack.config`, so the pin was silently ignored and the app fell back to the buildpack default `node_version=latest`.

That default is not benign. It resolves against `https://nodejs.org/dist/latest/`, so every build installs whatever Node was published most recently — brand new majors, on release day. A real customer build hit exactly this: it had `nodejs 22.19.0` pinned, resolved v26.6.0 (published three hours earlier), and died in the checksum lookup. #31 made that failure loud; this makes the pin work in the first place.

## How

`extract_asdf_version()` in `lib/common.sh` mirrors the function of the same name in the Elixir buildpack — same `grep | tail -n 1 | awk` shape, same `|| true` guard so a missing entry isn't an error under `pipefail`.

Precedence matches the Elixir buildpack: buildpack defaults → `.tool-versions` → `phoenix_static_buildpack.config`. An app with an explicit `node_version` in its config file sees no change.

One addition beyond a strict mirror, easy to drop if you'd rather not have it: asdf also accepts aliases like `lts/jod` and `system`. Those can't be resolved, and `fix_node_version` would quietly reduce them to the empty string, i.e. back to `latest`. They're ignored with a warning instead.

## Testing

Six cases added to the `load_config` suite in `test/common_test.sh`: reads the version, config file overrides it, no `nodejs` entry keeps the default, repeated entries take the last, aliases are ignored, and a file with no trailing newline still parses. Verified they fail against `main` before the change.

Full `make test` passes. Also ran `load_config` against the customer source that triggered this:

```
       Loading config...
       Detected nodejs 22.19.0 in .tool-versions
       The config file phoenix_static_buildpack.config wasn't found
       ...
       Will use the following versions:
       * Node 22.19.0
```

Previously the last line read `* Node` with nothing after it.

## Notes

Only the `nodejs` key is read. `npm`, `yarn`, and `pnpm` versions still come from the config file — asdf plugin names for those don't map as cleanly, and no app has asked for it.
